### PR TITLE
Update vite glsl config

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -36,7 +36,7 @@
         "tailwindcss": "^4.0.9",
         "typescript-eslint": "^8.25.0",
         "vite": "^6.2.0",
-        "vite-plugin-glsl": "^1.3.3",
+        "vite-plugin-glsl": "^1.4.1",
         "vue-tsc": "^2.2.8",
       },
       "peerDependencies": {
@@ -741,7 +741,7 @@
 
     "vite": ["vite@6.2.0", "", { "dependencies": { "esbuild": "^0.25.0", "postcss": "^8.5.3", "rollup": "^4.30.1" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ=="],
 
-    "vite-plugin-glsl": ["vite-plugin-glsl@1.3.3", "", { "dependencies": { "@rollup/pluginutils": "^5.1.4" }, "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0" } }, "sha512-ZN1PjwPN9MTqt75SAZHcNr9A4IFtxFxZsPwApVuhhnSSeDPk6ezD8LUmcoTQtZwerNT3vWiwv3+zSspT+8yInQ=="],
+    "vite-plugin-glsl": ["vite-plugin-glsl@1.4.1", "", { "dependencies": { "@rollup/pluginutils": "^5.1.4" }, "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0" } }, "sha512-LkfLZeHdyl0drA71GmCCfcTeLuXyn/DYwDfjzQrupvNYVwdFRvb7nkCnCm0o9LZRKxS4/8r7E3KNM7KQjWrWWQ=="],
 
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,7 @@
     "tailwindcss": "^4.0.9",
     "typescript-eslint": "^8.25.0",
     "vite": "^6.2.0",
-    "vite-plugin-glsl": "^1.3.3",
+    "vite-plugin-glsl": "^1.4.1",
     "vue-tsc": "^2.2.8"
   },
   "peerDependencies": {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
       warnDuplicatedImports: true, // Warn if the same chunk was imported multiple times
       removeDuplicatedImports: false, // Automatically remove an already imported chunk
       defaultExtension: "glsl", // Shader suffix when no extension is specified
-      compress: false, // Compress output shader code
       watch: true, // Recompile shader on change
       root: "/", // Directory for root imports
     }),

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2406,10 +2406,10 @@ varint@^6.0.0:
     postcss "^8.5.3"
     rollup "^4.30.1"
 
-vite-plugin-glsl@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/vite-plugin-glsl/-/vite-plugin-glsl-1.3.3.tgz"
-  integrity sha512-ZN1PjwPN9MTqt75SAZHcNr9A4IFtxFxZsPwApVuhhnSSeDPk6ezD8LUmcoTQtZwerNT3vWiwv3+zSspT+8yInQ==
+vite-plugin-glsl@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/vite-plugin-glsl/-/vite-plugin-glsl-1.4.1.tgz"
+  integrity sha512-LkfLZeHdyl0drA71GmCCfcTeLuXyn/DYwDfjzQrupvNYVwdFRvb7nkCnCm0o9LZRKxS4/8r7E3KNM7KQjWrWWQ==
   dependencies:
     "@rollup/pluginutils" "^5.1.4"
 


### PR DESCRIPTION
### Summary of Changes

- [Updated vite-plugin-glsl to 1.4.1](https://github.com/timrlai/timrlai/commit/b9be83dd62858cfcc04477be6d24e2e7b6f3ad61)
- [Removed deprecated compress prop from glsl config](https://github.com/timrlai/timrlai/commit/bdbbb45d951640c80a78d97e4b92972c00122b5a)

The deploy was failing since it was using a more recent version of vite-plugin-glsl which did not use the compress prop.
