### PR TITLE
Mobile optimization: Stop setPoses from being called when resize event is fired when scrolling on mobile

### DIFF
--- a/frontend/lib/constants/LogoCanvas.ts
+++ b/frontend/lib/constants/LogoCanvas.ts
@@ -19,6 +19,15 @@ const constants: LogoCanvasConstants = {
   DESKTOP_TAGLINE_SCALE: 1,
   WIDE_LOGO_ROTATION: [0, 0.2, 0],
   WIDE_TAGLINE_ROTATION: [0, -0.5, 0],
+  CANVAS_COLOR: "#C0FCF9",
+  TEXT_COLOR: "#006177",
+  AMBIENT_LIGHT_COLOR: "#C0FCF9",
+  DIRECTIONAL_LIGHT_COLOR: "#FFFAD4",
+  VERTICAL_ROTATION_LIMIT: 1.6,
+  HORIZONTAL_ROTATION_LIMIT: 6,
+  FONT_PATH: "/fonts/ubuntu_titling/Ubuntu_Titlin_Rg_Bold.json",
+  FONT_SIZE: 1,
+  LOGO_GLTF_PATH: "/models/timrlai_logo.gltf",
 };
 
 export default constants;

--- a/frontend/lib/constants/NotFoundCanvas.ts
+++ b/frontend/lib/constants/NotFoundCanvas.ts
@@ -19,6 +19,15 @@ const constants: NotFoundCanvasConstants = {
   DESKTOP_EXPLANATION_SCALE: 1,
   WIDE_LOTTIE_ROTATION: [0, -0.5, 0],
   WIDE_EXPLANATION_ROTATION: [0, -0.5, 0],
+  CANVAS_COLOR: "#C0FCF9",
+  TEXT_COLOR: "#006177",
+  AMBIENT_LIGHT_COLOR: "#C0FCF9",
+  DIRECTIONAL_LIGHT_COLOR: "#FFFAD4",
+  VERTICAL_ROTATION_LIMIT: 1.6,
+  HORIZONTAL_ROTATION_LIMIT: 6,
+  FONT_PATH: "/fonts/ubuntu_titling/Ubuntu_Titlin_Rg_Bold.json",
+  TITLE_FONT_SIZE: 1,
+  EXPLANATION_FONT_SIZE: 0.7,
 };
 
 export default constants;

--- a/frontend/lib/types/index.ts
+++ b/frontend/lib/types/index.ts
@@ -89,29 +89,19 @@ export type LottieCylinderProps = LottieShapeProps & {
   theataEnd?: number;
 };
 
-export type CloudCanvasProps = {
-  canvasColor?: string;
-  textColor?: string;
-  ambientLightColor?: string;
-  directionalLightColor?: string;
-  verticalRotationLimit?: number;
-  horizontalRotationLimit?: number;
-  fontPath?: string;
-};
-
-export type LogoCanvasProps = CloudCanvasProps & {
-  gltfPath?: string;
-  fontSize?: number;
-};
-
-export type NotFoundCanvasProps = CloudCanvasProps & {
-  titleFontSize?: number;
-  explanationFontSize?: number;
-};
-
-export type LogoCanvasConstants = {
+type CanvasConstants = {
   readonly WIDTH_BREAKPOINT: number;
   readonly HEIGHT_BREAKPOINT: number;
+  readonly CANVAS_COLOR: string;
+  readonly TEXT_COLOR: string;
+  readonly AMBIENT_LIGHT_COLOR: string;
+  readonly DIRECTIONAL_LIGHT_COLOR: string;
+  readonly VERTICAL_ROTATION_LIMIT: number;
+  readonly HORIZONTAL_ROTATION_LIMIT: number;
+  readonly FONT_PATH: string;
+};
+
+export type LogoCanvasConstants = CanvasConstants & {
   readonly PORTRAIT_LOGO_POSITION: [number, number, number];
   readonly PORTRAIT_LOGO_ROTATION: [number, number, number];
   readonly PORTRAIT_LOGO_SCALE: number;
@@ -128,9 +118,11 @@ export type LogoCanvasConstants = {
   readonly DESKTOP_TAGLINE_SCALE: number;
   readonly WIDE_LOGO_ROTATION: [number, number, number];
   readonly WIDE_TAGLINE_ROTATION: [number, number, number];
+  readonly LOGO_GLTF_PATH: string;
+  readonly FONT_SIZE: number;
 };
 
-export type NotFoundCanvasConstants = {
+export type NotFoundCanvasConstants = CanvasConstants & {
   readonly WIDTH_BREAKPOINT: number;
   readonly HEIGHT_BREAKPOINT: number;
   readonly PORTRAIT_LOTTIE_POSITION: [number, number, number];
@@ -149,4 +141,6 @@ export type NotFoundCanvasConstants = {
   readonly DESKTOP_EXPLANATION_SCALE: number;
   readonly WIDE_LOTTIE_ROTATION: [number, number, number];
   readonly WIDE_EXPLANATION_ROTATION: [number, number, number];
+  readonly TITLE_FONT_SIZE: number;
+  readonly EXPLANATION_FONT_SIZE: number;
 };

--- a/frontend/src/components/3D/LogoCanvas.vue
+++ b/frontend/src/components/3D/LogoCanvas.vue
@@ -66,13 +66,18 @@ const isMobileOrTablet: boolean = isMobile() || isMobile({ tablet: true });
 const { scene } = await useGLTF(gltfPath, { draco: true });
 let logoModel: Scene = scene;
 
-const setPoses = () => {
+const setPoses = (event: Event | null = null) => {
   setTimeout(
     async () => {
       const currentWidth: number = window?.innerWidth;
       const currentHeight: number = window?.innerHeight;
 
-      if (!currentWidth || !currentHeight || currentWidth === width) return;
+      if (
+        !currentWidth ||
+        !currentHeight ||
+        (event && event.type === "resize" && currentWidth === width)
+      )
+        return;
 
       width = currentWidth;
       height = currentHeight;

--- a/frontend/src/components/3D/LogoCanvas.vue
+++ b/frontend/src/components/3D/LogoCanvas.vue
@@ -1,33 +1,13 @@
 <script setup lang="ts">
-import {
-  type Ref,
-  defineProps,
-  ref,
-  onMounted,
-  onUnmounted,
-  watchEffect,
-} from "vue";
+import { type Ref, ref, onMounted, onUnmounted, watchEffect } from "vue";
 import type { Scene } from "three";
 import isMobile from "is-mobile";
 import { TresCanvas } from "@tresjs/core";
 import { useGLTF, OrbitControls, Text3D } from "@tresjs/cientos";
 
-import type { LogoCanvasProps } from "../../../lib/types";
 import constants from "../../../lib/constants/LogoCanvas";
 import LottieSphere from "./LottieSphere.vue";
 import GLCloud from "./GLCloud.vue";
-
-const {
-  canvasColor = "#C0FCF9",
-  textColor = "#006177",
-  ambientLightColor = "#C0FCF9",
-  directionalLightColor = "#FFFAD4",
-  verticalRotationLimit = 1.6,
-  horizontalRotationLimit = 6,
-  gltfPath = "/models/timrlai_logo.gltf",
-  fontPath = "/fonts/ubuntu_titling/Ubuntu_Titlin_Rg_Bold.json",
-  fontSize = 1,
-} = defineProps<LogoCanvasProps>();
 
 const {
   WIDTH_BREAKPOINT,
@@ -48,6 +28,15 @@ const {
   DESKTOP_TAGLINE_SCALE,
   WIDE_LOGO_ROTATION,
   WIDE_TAGLINE_ROTATION,
+  CANVAS_COLOR,
+  TEXT_COLOR,
+  AMBIENT_LIGHT_COLOR,
+  DIRECTIONAL_LIGHT_COLOR,
+  VERTICAL_ROTATION_LIMIT,
+  HORIZONTAL_ROTATION_LIMIT,
+  FONT_PATH,
+  FONT_SIZE,
+  LOGO_GLTF_PATH,
 } = constants;
 
 let width: number = window?.innerWidth || WIDTH_BREAKPOINT;
@@ -63,7 +52,7 @@ let taglineScale: number = PORTRAIT_TAGLINE_SCALE;
 
 const canvasKey: Ref<string> = ref("logo-canvas");
 const isMobileOrTablet: boolean = isMobile() || isMobile({ tablet: true });
-const { scene } = await useGLTF(gltfPath, { draco: true });
+const { scene } = await useGLTF(LOGO_GLTF_PATH, { draco: true });
 let logoModel: Scene = scene;
 
 const setPoses = (event: Event | null = null) => {
@@ -109,7 +98,7 @@ const setPoses = (event: Event | null = null) => {
           ? LANDSCAPE_TAGLINE_SCALE
           : DESKTOP_TAGLINE_SCALE;
 
-      const { scene } = await useGLTF(gltfPath, { draco: true });
+      const { scene } = await useGLTF(LOGO_GLTF_PATH, { draco: true });
       logoModel = scene;
 
       // Regenerate the value of the key prop of the canvas to rerender it after resetting poses
@@ -145,16 +134,16 @@ watchEffect(() => {
     ></div>
     <h1 class="visually-hidden">Tim RL dot AI</h1>
     <h2 class="visually-hidden">A full stack team in one Tim!</h2>
-    <TresCanvas :key="canvasKey" :clear-color="canvasColor" shadows alpha>
+    <TresCanvas :key="canvasKey" :clear-color="CANVAS_COLOR" shadows alpha>
       <TresPerspectiveCamera :position="[0, 0, 1]" />
       <OrbitControls
         v-if="!(isLandscape && isMobileOrTablet)"
         :minDistance="0"
         :maxDistance="Infinity"
         :minPolarAngle="0"
-        :maxPolarAngle="Math.PI / verticalRotationLimit"
-        :minAzimuthAngle="-(Math.PI / horizontalRotationLimit)"
-        :maxAzimuthAngle="Math.PI / horizontalRotationLimit"
+        :maxPolarAngle="Math.PI / VERTICAL_ROTATION_LIMIT"
+        :minAzimuthAngle="-(Math.PI / HORIZONTAL_ROTATION_LIMIT)"
+        :maxAzimuthAngle="Math.PI / HORIZONTAL_ROTATION_LIMIT"
       />
       <Suspense>
         <LottieSphere src="/lottie/clouds_lottie.json" />
@@ -173,26 +162,26 @@ watchEffect(() => {
       >
         <Suspense
           ><TresMesh :position="[0, 2, 0]"
-            ><Text3D :font="fontPath" :size="fontSize"
-              >A FULL <TresMeshStandardMaterial :color="textColor" /></Text3D
+            ><Text3D :font="FONT_PATH" :size="FONT_SIZE"
+              >A FULL <TresMeshStandardMaterial :color="TEXT_COLOR" /></Text3D
           ></TresMesh>
         </Suspense>
         <Suspense
           ><TresMesh :position="[0, 0.7, 0]"
-            ><Text3D :font="fontPath" :size="fontSize"
-              >STACK <TresMeshStandardMaterial :color="textColor" /></Text3D
+            ><Text3D :font="FONT_PATH" :size="FONT_SIZE"
+              >STACK <TresMeshStandardMaterial :color="TEXT_COLOR" /></Text3D
           ></TresMesh>
         </Suspense>
         <Suspense
           ><TresMesh :position="[0, -0.7, 0]"
-            ><Text3D :font="fontPath" :size="fontSize"
-              >TEAM iN <TresMeshStandardMaterial :color="textColor" /></Text3D
+            ><Text3D :font="FONT_PATH" :size="FONT_SIZE"
+              >TEAM iN <TresMeshStandardMaterial :color="TEXT_COLOR" /></Text3D
           ></TresMesh>
         </Suspense>
         <Suspense
           ><TresMesh :position="[0, -2, 0]"
-            ><Text3D :font="fontPath" :size="fontSize"
-              >ONE TiM! <TresMeshStandardMaterial :color="textColor" /></Text3D
+            ><Text3D :font="FONT_PATH" :size="FONT_SIZE"
+              >ONE TiM! <TresMeshStandardMaterial :color="TEXT_COLOR" /></Text3D
           ></TresMesh>
         </Suspense>
       </TresMesh>
@@ -202,13 +191,13 @@ watchEffect(() => {
       <TresAmbientLight
         :position="[0, 10, 0]"
         :intensity="5"
-        :color="ambientLightColor"
+        :color="AMBIENT_LIGHT_COLOR"
       />
       <TresDirectionalLight
         :position="[-4, 8, 4]"
         :rotation="[0, 0, 0]"
         :intensity="10"
-        :color="directionalLightColor"
+        :color="DIRECTIONAL_LIGHT_COLOR"
       />
     </TresCanvas>
   </section>

--- a/frontend/src/components/3D/LogoCanvas.vue
+++ b/frontend/src/components/3D/LogoCanvas.vue
@@ -50,6 +50,8 @@ const {
   WIDE_TAGLINE_ROTATION,
 } = constants;
 
+let width: number = window?.innerWidth || WIDTH_BREAKPOINT;
+let height: number = window?.innerHeight || HEIGHT_BREAKPOINT;
 let isPortrait: boolean = true;
 let isLandscape: boolean = false;
 let logoPosition: [number, number, number] = PORTRAIT_LOGO_POSITION;
@@ -67,11 +69,13 @@ let logoModel: Scene = scene;
 const setPoses = () => {
   setTimeout(
     async () => {
-      const width: number = window?.innerWidth;
-      const height: number = window?.innerHeight;
+      const currentWidth: number = window?.innerWidth;
+      const currentHeight: number = window?.innerHeight;
 
-      if (!width || !height) return;
+      if (!currentWidth || !currentHeight || currentWidth === width) return;
 
+      width = currentWidth;
+      height = currentHeight;
       isPortrait = width <= WIDTH_BREAKPOINT && width < height;
       isLandscape = height <= HEIGHT_BREAKPOINT && height < width;
 

--- a/frontend/src/components/3D/NotFoundCanvas.vue
+++ b/frontend/src/components/3D/NotFoundCanvas.vue
@@ -1,34 +1,14 @@
 <script setup lang="ts">
-import {
-  type Ref,
-  defineProps,
-  ref,
-  onMounted,
-  onUnmounted,
-  watchEffect,
-} from "vue";
+import { type Ref, ref, onMounted, onUnmounted, watchEffect } from "vue";
 import isMobile from "is-mobile";
 import { TresCanvas } from "@tresjs/core";
 import { OrbitControls, Text3D } from "@tresjs/cientos";
 
-import type { NotFoundCanvasProps } from "../../../lib/types";
 import { notFoundLotties } from "../../../lib/constants";
 import constants from "../../../lib/constants/NotFoundCanvas";
 import LottieSphere from "./LottieSphere.vue";
 import LottieCylinder from "./LottieCylinder.vue";
 import GLCloud from "./GLCloud.vue";
-
-const {
-  canvasColor = "#C0FCF9",
-  textColor = "#006177",
-  ambientLightColor = "#C0FCF9",
-  directionalLightColor = "#FFFAD4",
-  verticalRotationLimit = 1.6,
-  horizontalRotationLimit = 6,
-  fontPath = "/fonts/ubuntu_titling/Ubuntu_Titlin_Rg_Bold.json",
-  titleFontSize = 1,
-  explanationFontSize = 0.7,
-} = defineProps<NotFoundCanvasProps>();
 
 const {
   WIDTH_BREAKPOINT,
@@ -49,6 +29,15 @@ const {
   DESKTOP_EXPLANATION_SCALE,
   WIDE_LOTTIE_ROTATION,
   WIDE_EXPLANATION_ROTATION,
+  CANVAS_COLOR,
+  TEXT_COLOR,
+  AMBIENT_LIGHT_COLOR,
+  DIRECTIONAL_LIGHT_COLOR,
+  VERTICAL_ROTATION_LIMIT,
+  HORIZONTAL_ROTATION_LIMIT,
+  FONT_PATH,
+  TITLE_FONT_SIZE,
+  EXPLANATION_FONT_SIZE,
 } = constants;
 
 let width: number = window?.innerWidth || WIDTH_BREAKPOINT;
@@ -150,16 +139,16 @@ watchEffect(() => {
     <p class="visually-hidden">
       Sorry, the page {{ $route.path }} is not in the cloud.
     </p>
-    <TresCanvas :key="canvasKey" :clear-color="canvasColor" shadows alpha>
+    <TresCanvas :key="canvasKey" :clear-color="CANVAS_COLOR" shadows alpha>
       <TresPerspectiveCamera :position="[0, 0, 1]" />
       <OrbitControls
         v-if="!(isLandscape && isMobileOrTablet)"
         :minDistance="0"
         :maxDistance="Infinity"
         :minPolarAngle="0"
-        :maxPolarAngle="Math.PI / verticalRotationLimit"
-        :minAzimuthAngle="-(Math.PI / horizontalRotationLimit)"
-        :maxAzimuthAngle="Math.PI / horizontalRotationLimit"
+        :maxPolarAngle="Math.PI / VERTICAL_ROTATION_LIMIT"
+        :minAzimuthAngle="-(Math.PI / HORIZONTAL_ROTATION_LIMIT)"
+        :maxAzimuthAngle="Math.PI / HORIZONTAL_ROTATION_LIMIT"
       />
       <Suspense>
         <LottieSphere src="/lottie/clouds_lottie.json" />
@@ -179,30 +168,30 @@ watchEffect(() => {
       >
         <Suspense
           ><TresMesh :position="[0, -1, 0]"
-            ><Text3D :font="fontPath" :size="titleFontSize"
+            ><Text3D :font="FONT_PATH" :size="TITLE_FONT_SIZE"
               >OOPSiE WOOPSiE!
-              <TresMeshStandardMaterial :color="textColor" /></Text3D
+              <TresMeshStandardMaterial :color="TEXT_COLOR" /></Text3D
           ></TresMesh>
         </Suspense>
         <Suspense
           ><TresMesh :position="[0, -2.7, 0]"
-            ><Text3D :font="fontPath" :size="titleFontSize"
+            ><Text3D :font="FONT_PATH" :size="TITLE_FONT_SIZE"
               >PAGE NOT FOUND!
-              <TresMeshStandardMaterial :color="textColor" /></Text3D
+              <TresMeshStandardMaterial :color="TEXT_COLOR" /></Text3D
           ></TresMesh>
         </Suspense>
         <Suspense
           ><TresMesh :position="[0, -4.7, 0]"
-            ><Text3D :font="fontPath" :size="explanationFontSize"
+            ><Text3D :font="FONT_PATH" :size="EXPLANATION_FONT_SIZE"
               >Sowwy, the page "{{ $route.path }}"
-              <TresMeshStandardMaterial :color="textColor" /></Text3D
+              <TresMeshStandardMaterial :color="TEXT_COLOR" /></Text3D
           ></TresMesh>
         </Suspense>
         <Suspense
           ><TresMesh :position="[0, -6, 0]"
-            ><Text3D :font="fontPath" :size="explanationFontSize"
+            ><Text3D :font="FONT_PATH" :size="EXPLANATION_FONT_SIZE"
               >is not in the cloud.
-              <TresMeshStandardMaterial :color="textColor" /></Text3D
+              <TresMeshStandardMaterial :color="TEXT_COLOR" /></Text3D
           ></TresMesh>
         </Suspense>
       </TresMesh>
@@ -212,13 +201,13 @@ watchEffect(() => {
       <TresAmbientLight
         :position="[0, 10, 0]"
         :intensity="5"
-        :color="ambientLightColor"
+        :color="AMBIENT_LIGHT_COLOR"
       />
       <TresDirectionalLight
         :position="[-4, 8, 4]"
         :rotation="[0, 0, 0]"
         :intensity="10"
-        :color="directionalLightColor"
+        :color="DIRECTIONAL_LIGHT_COLOR"
       />
     </TresCanvas>
   </section>

--- a/frontend/src/components/3D/NotFoundCanvas.vue
+++ b/frontend/src/components/3D/NotFoundCanvas.vue
@@ -51,6 +51,8 @@ const {
   WIDE_EXPLANATION_ROTATION,
 } = constants;
 
+let width: number = window?.innerWidth || WIDTH_BREAKPOINT;
+let height: number = window?.innerHeight || HEIGHT_BREAKPOINT;
 let isPortrait: boolean = true;
 let isLandscape: boolean = false;
 let lottiePosition: [number, number, number] = PORTRAIT_LOTTIE_POSITION;
@@ -69,11 +71,13 @@ const randomNotFoundLottie: string = `/lottie/404/${notFoundLotties[Math.floor(M
 const setPoses = () => {
   setTimeout(
     () => {
-      const width: number = window?.innerWidth;
-      const height: number = window?.innerHeight;
+      const currentWidth: number = window?.innerWidth;
+      const currentHeight: number = window?.innerHeight;
 
-      if (!width || !height) return;
+      if (!currentWidth || !currentHeight || currentWidth === width) return;
 
+      width = currentWidth;
+      height = currentHeight;
       isPortrait = width <= WIDTH_BREAKPOINT && width < height;
       isLandscape = height <= HEIGHT_BREAKPOINT && height < width;
 

--- a/frontend/src/components/3D/NotFoundCanvas.vue
+++ b/frontend/src/components/3D/NotFoundCanvas.vue
@@ -68,13 +68,18 @@ const canvasKey: Ref<string> = ref("not-found-canvas");
 const isMobileOrTablet: boolean = isMobile() || isMobile({ tablet: true });
 const randomNotFoundLottie: string = `/lottie/404/${notFoundLotties[Math.floor(Math.random() * notFoundLotties.length)]}`;
 
-const setPoses = () => {
+const setPoses = (event: Event | null = null) => {
   setTimeout(
     () => {
       const currentWidth: number = window?.innerWidth;
       const currentHeight: number = window?.innerHeight;
 
-      if (!currentWidth || !currentHeight || currentWidth === width) return;
+      if (
+        !currentWidth ||
+        !currentHeight ||
+        (event && event.type === "resize" && currentWidth === width)
+      )
+        return;
 
       width = currentWidth;
       height = currentHeight;

--- a/frontend/src/components/Layout/PageFooter.vue
+++ b/frontend/src/components/Layout/PageFooter.vue
@@ -7,7 +7,11 @@ const year = new Date().getFullYear();
 
 <template>
   <div class="mb-10 lg:mb-0">
-    <LottiePlayer src="/lottie/clouds_lottie.json" autoPlay />
+    <LottiePlayer
+      src="/lottie/clouds_lottie.json"
+      :autoPlay="false"
+      :playOnHover="true"
+    />
   </div>
   <footer
     class="footer footer-horizontal lg:footer-vertical footer-center bg-accent text-accent-content p-10 relative text-center atkinson-hyperlegible-next-bold text-2xl"
@@ -55,7 +59,7 @@ footer::before {
   height: 50px;
   transform: translateY(0) translateZ(0) rotateZ(360deg);
 }
-footer::before {
+footer:hover::before {
   animation: wind 2s infinite;
 }
 @keyframes wind {

--- a/frontend/src/components/Pages/Home/Skills.vue
+++ b/frontend/src/components/Pages/Home/Skills.vue
@@ -40,17 +40,17 @@ const randomizedSkills = [...primarySkills]
       </h1>
     </div>
     <div
-      class="mockup-code bg-slate-800 text-slate-300 border-x-4 border-primary rounded-none shadow-lg shadow-primary fira-code"
+      class="mockup-code bg-slate-800 text-slate-300 border-x-4 border-primary rounded-none shadow-lg shadow-primary fira-code overflow-x-hidden"
     >
       <div class="px-5">
-        <h2 class="text-2xl sm:text-3xl mb-4 code-comment-inline">
+        <h2 class="text-xl sm:text-2xl mb-4 code-comment-inline">
           Technical Skills
           <Icon icon="fluent-color:code-20" class="inline-block" /><Icon
             icon="fluent-color:design-ideas-20"
             class="inline-block"
           />
         </h2>
-        <div class="text-xl/10 sm:text-2xl/12">
+        <div class="text-lg/8 sm:text-xl/10">
           <p class="code-comment-block">
             My skills include developing, designing, testing, debugging and
             troubleshooting websites and applications in a wide variety of
@@ -102,7 +102,7 @@ const randomizedSkills = [...primarySkills]
         </div>
         <div class="collapse collapse-plus mt-5">
           <input type="checkbox" />
-          <h3 class="collapse-title text-xl sm:text-2xl ubuntu-bold bg-neutral">
+          <h3 class="collapse-title text-lg sm:text-xl ubuntu-bold bg-neutral">
             Click to View All Technical Skills
           </h3>
           <div class="overflow-x-auto">
@@ -273,14 +273,16 @@ const randomizedSkills = [...primarySkills]
           </div>
         </div>
         <div class="mt-8">
-          <h2 class="text-2xl sm:text-3xl mb-4 code-comment-inline">
+          <h2 class="text-xl sm:text-2xl mb-4 code-comment-inline">
             This Site Was Made With...
             <Icon icon="fluent-color:code-20" class="inline-block" /><Icon
               icon="fluent-color:design-ideas-20"
               class="inline-block"
             />
           </h2>
-          <div class="flex flex-wrap gap-2 text-7xl sm:text-9xl">
+          <div
+            class="flex flex-wrap gap-2 text-6xl sm:text-7xl md:text-8xl lg:text-9xl"
+          >
             <div
               v-for="skills in madeWithSkills"
               v-bind:key="skills.title"


### PR DESCRIPTION
### Summary of Changes

- [Prevent resize event from firing on mobile unless width changes](https://github.com/timrlai/timrlai/commit/40f4213c31428337712ee9149d48eb3fb22a6085)
- [Added check if event type is resize to check if width changed](https://github.com/timrlai/timrlai/commit/7cf39626254a82fb639e0089c3036c64070b9979)
- [Converted props for canvas components to constants](https://github.com/timrlai/timrlai/commit/44def2cd737854a3730ef975e67d99822c619bbb)
- [Updated font sizes in skills section](https://github.com/timrlai/timrlai/commit/a2ffbc26a2b862a6eb64df98d0e4804dc61c7b39)