### PR TITLE
Added prefix attributes to meta og tags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,24 +23,43 @@
 
     <!-- Open Graph tags for Facebook/LinkedIn/WhatsApp etc. links -->
     <meta
+      prefix="og: http://ogp.me/ns#"
       property="og:title"
       content="Tim R. Lai: Developer/Teacher/Designer/Illustrator"
     />
     <meta
+      prefix="og: http://ogp.me/ns#"
       property="og:description"
       content="Full-stack software/web developer, teacher, designer/illustrator"
     />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://timrl.ai" />
-    <meta property="og:image:url" content="https://timrl.ai/og_image.png" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:image:type" content="image/png" />
+    <meta prefix="og: http://ogp.me/ns#" property="og:type" content="website" />
     <meta
+      prefix="og: http://ogp.me/ns#"
+      property="og:url"
+      content="https://timrl.ai"
+    />
+    <meta property="og:image:url" content="https://timrl.ai/og_image.png" />
+    <meta
+      prefix="og: http://ogp.me/ns#"
+      property="og:image:width"
+      content="1200"
+    />
+    <meta
+      prefix="og: http://ogp.me/ns#"
+      property="og:image:height"
+      content="630"
+    />
+    <meta
+      prefix="og: http://ogp.me/ns#"
+      property="og:image:type"
+      content="image/png"
+    />
+    <meta
+      prefix="og: http://ogp.me/ns#"
       property="og:image:alt"
       content="A logo reads Tim R. Lai and a tagline to the right of it reads A Full Stack Team in One Tim. There is a cartoon depiction of Tim R. Lai's face to the right of the logo. The titles Developer, Teacher, Designer and Illustrator are listed underneath the logo, tagline and face. There are cartoon clouds at the bottom."
     />
-    <meta property="og:locale" content="en_US" />
+    <meta prefix="og: http://ogp.me/ns#" property="og:locale" content="en_US" />
 
     <!-- Twitter Card tags for Twitter/X links - These should probably be called "X Card" tags now but I guess they didn't want to break every site that uses them when they rebranded -->
     <meta name="twitter:card" content="summary" />


### PR DESCRIPTION
### Reason for Change
These seem to be necessary to get open graph tags to work on LinkedIn.