### PR TITLE
TresJS: Set @tresjs/core and @tresjs/cientos to use exact current versions to avoid bugs breaking shaders and OrbitControls

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,8 +20,8 @@
     ]
   },
   "dependencies": {
-    "@tresjs/cientos": "^4.2.0",
-    "@tresjs/core": "^4.3.3",
+    "@tresjs/cientos": "4.2.0",
+    "@tresjs/core": "4.3.3",
     "is-mobile": "^5.0.0",
     "three": "^0.174.0",
     "vue": "^3.5.13",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -88,6 +88,7 @@ export default defineConfig({
       warnDuplicatedImports: true, // Warn if the same chunk was imported multiple times
       removeDuplicatedImports: false, // Automatically remove an already imported chunk
       defaultExtension: "glsl", // Shader suffix when no extension is specified
+      minify: true, // Minify/optimize output shader code
       watch: true, // Recompile shader on change
       root: "/", // Directory for root imports
     }),


### PR DESCRIPTION
### Summary of Changes

- [Added minify prop to glsl options in vite config](https://github.com/timrlai/timrlai/commit/33d249d7e6c28b823d05929914482f4fd2d2448d)
- [Set tresjs packages to use exact versions](https://github.com/timrlai/timrlai/commit/b073fcaa0878db5c6db36a2095e046810a6f8707)

The latest version of tresjs is causing bugs which are breaking shaders and OrbitControls.