### PR TITLE
Replace LottieLoader with lottie-web

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -9,6 +9,7 @@
         "@tresjs/core": "^5.8.0",
         "@vueuse/core": "^14.2.1",
         "is-mobile": "^5.0.0",
+        "lottie-web": "^5.13.0",
         "pinia": "^3.0.4",
         "three": "^0.183.2",
         "vue": "^3.5.32",
@@ -923,7 +924,7 @@
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
-    "lottie-web": ["lottie-web@5.12.2", "", {}, "sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg=="],
+    "lottie-web": ["lottie-web@5.13.0", "", {}, "sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ=="],
 
     "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
@@ -1458,6 +1459,8 @@
     "vue-router/@vue/devtools-api": ["@vue/devtools-api@8.1.1", "", { "dependencies": { "@vue/devtools-kit": "^8.1.1" } }, "sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw=="],
 
     "vue-router/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "vue3-lottie/lottie-web": ["lottie-web@5.12.2", "", {}, "sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 

--- a/frontend/lib/three/loaders/LottieLoader.ts
+++ b/frontend/lib/three/loaders/LottieLoader.ts
@@ -1,7 +1,13 @@
 import lottie from "lottie-web";
 import type { AnimationConfig, AnimationItem } from "lottie-web";
 import type { LottieTexture } from "../../types";
-import { Loader, CanvasTexture, NearestFilter, FileLoader } from "three";
+import {
+  Loader,
+  CanvasTexture,
+  NearestFilter,
+  FileLoader,
+  SRGBColorSpace,
+} from "three";
 
 type AnimationItemWithContainer = AnimationItem & {
   container: Element;
@@ -47,6 +53,7 @@ class LottieLoader extends Loader {
         } as AnimationConfig<"canvas">) as AnimationItemWithContainer;
         texture.animation = animation;
         texture.image = animation.container;
+        texture.colorSpace = SRGBColorSpace;
         animation.addEventListener("enterFrame", function () {
           texture.needsUpdate = true;
         });

--- a/frontend/lib/three/loaders/LottieLoader.ts
+++ b/frontend/lib/three/loaders/LottieLoader.ts
@@ -1,0 +1,64 @@
+import lottie from "lottie-web";
+import type { AnimationConfig, AnimationItem } from "lottie-web";
+import type { LottieTexture } from "../../types";
+import { Loader, CanvasTexture, NearestFilter, FileLoader } from "three";
+
+type AnimationItemWithContainer = AnimationItem & {
+  container: Element;
+};
+
+class LottieLoader extends Loader {
+  private _quality: number;
+  constructor() {
+    super();
+    this._quality = 1;
+  }
+  setQuality(value: number) {
+    this._quality = value;
+  }
+  load(
+    url: string,
+    onLoad: (data: unknown) => void,
+    onProgress: (event: ProgressEvent<EventTarget>) => void,
+    onError: (err: unknown) => void,
+  ) {
+    const quality = this._quality || 1;
+    const canvas = document.createElement("canvas");
+    const texture: LottieTexture = new CanvasTexture(canvas);
+    texture.minFilter = NearestFilter;
+    const loader = new FileLoader(this.manager);
+    loader.setPath(this.path);
+    loader.setWithCredentials(this.withCredentials);
+    loader.load(
+      url,
+      function (text) {
+        const data = JSON.parse(text as string);
+        const container = document.createElement("div");
+        container.style.width = data.w + "px";
+        container.style.height = data.h + "px";
+        document.body.appendChild(container);
+        const animation = lottie.loadAnimation<"canvas">({
+          container,
+          animType: "canvas",
+          loop: true,
+          autoplay: true,
+          animationData: data,
+          rendererSettings: { dpr: quality },
+        } as AnimationConfig<"canvas">) as AnimationItemWithContainer;
+        texture.animation = animation;
+        texture.image = animation.container;
+        animation.addEventListener("enterFrame", function () {
+          texture.needsUpdate = true;
+        });
+        container.style.display = "none";
+        if (onLoad !== void 0) {
+          onLoad(texture);
+        }
+      },
+      onProgress,
+      onError,
+    );
+    return texture;
+  }
+}
+export { LottieLoader };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@tresjs/core": "^5.8.0",
     "@vueuse/core": "^14.2.1",
     "is-mobile": "^5.0.0",
+    "lottie-web": "^5.13.0",
     "pinia": "^3.0.4",
     "three": "^0.183.2",
     "vue": "^3.5.32",

--- a/frontend/src/components/3D/LottieCylinder.vue
+++ b/frontend/src/components/3D/LottieCylinder.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ClampToEdgeWrapping, FrontSide } from "three/src/constants.js";
-import { LottieLoader } from "three/addons/loaders/LottieLoader.js";
+import { LottieLoader } from "../../../lib/three/loaders/LottieLoader";
 import { type LoaderProto, useLoader } from "@tresjs/core";
 import { Cylinder } from "@tresjs/cientos";
 import type { LottieTexture, LottieCylinderProps } from "../../../lib/types";
@@ -31,7 +31,7 @@ const {
 
 const lottieTexture: LottieTexture = (
   await useLoader(LottieLoader as LoaderProto<LottieTexture>, src)
-).state.value as LottieTexture;
+).state.value;
 
 lottieTexture.repeat.x = repeatX;
 lottieTexture.repeat.y = repeatY;

--- a/frontend/src/components/3D/LottiePlane.vue
+++ b/frontend/src/components/3D/LottiePlane.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ClampToEdgeWrapping, FrontSide } from "three/src/constants.js";
-import { LottieLoader } from "three/addons/loaders/LottieLoader.js";
+import { LottieLoader } from "../../../lib/three/loaders/LottieLoader";
 import { type LoaderProto, useLoader } from "@tresjs/core";
 import { Plane } from "@tresjs/cientos";
 import type { LottieTexture, LottiePlaneProps } from "../../../lib/types";
@@ -27,7 +27,7 @@ const {
 
 const lottieTexture: LottieTexture = (
   await useLoader(LottieLoader as LoaderProto<LottieTexture>, src)
-).state.value as LottieTexture;
+).state.value;
 
 lottieTexture.repeat.x = repeatX;
 lottieTexture.repeat.y = repeatY;

--- a/frontend/src/components/3D/LottieRoundedBox.vue
+++ b/frontend/src/components/3D/LottieRoundedBox.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ClampToEdgeWrapping, FrontSide } from "three/src/constants.js";
-import { LottieLoader } from "three/addons/loaders/LottieLoader.js";
+import { LottieLoader } from "../../../lib/three/loaders/LottieLoader";
 import { type LoaderProto, useLoader } from "@tresjs/core";
 import { RoundedBox } from "@tresjs/cientos";
 import type { LottieTexture, LottieRoundedBoxProps } from "../../../lib/types";
@@ -28,7 +28,7 @@ const {
 
 const lottieTexture: LottieTexture = (
   await useLoader(LottieLoader as LoaderProto<LottieTexture>, src)
-).state.value as LottieTexture;
+).state.value;
 
 lottieTexture.repeat.x = repeatX;
 lottieTexture.repeat.y = repeatY;

--- a/frontend/src/components/3D/LottieSphere.vue
+++ b/frontend/src/components/3D/LottieSphere.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RepeatWrapping, BackSide } from "three/src/constants.js";
-import { LottieLoader } from "three/addons/loaders/LottieLoader.js";
+import { LottieLoader } from "../../../lib/three/loaders/LottieLoader";
 import { type LoaderProto, useLoader } from "@tresjs/core";
 import { Sphere } from "@tresjs/cientos";
 import type { LottieTexture, LottieSphereProps } from "../../../lib/types";
@@ -25,7 +25,7 @@ const {
 
 const lottieTexture: LottieTexture = (
   await useLoader(LottieLoader as LoaderProto<LottieTexture>, src)
-).state.value as LottieTexture;
+).state.value;
 
 lottieTexture.repeat.x = repeatX;
 lottieTexture.repeat.y = repeatY;


### PR DESCRIPTION
### Description of Task

- Added lottie-web to package.json file
- Created custom, local LottieLoader class
- Updated LottieLoader import in LottieCylinder, LottiePlane, LottieRoundedBox and LottieSphere to point to local LottieLoader.ts file
- Removed now unnecessary "as LottieLoader" type conversion in LottieCylinder, LottiePlane, LottieRoundedBox and LottieSphere