### PR TITLE
Fixed Touch Events For 3D Canvas on Mobile

### DIFF
--- a/frontend/src/components/3D/LogoCanvas.vue
+++ b/frontend/src/components/3D/LogoCanvas.vue
@@ -721,9 +721,13 @@ watchEffect(() => {
     margin-bottom: -80vh;
   }
 }
+#logo-canvas canvas {
+  touch-action: pan-y !important;
+  pointer-events: none;
+}
 #scroll-track {
   position: absolute;
   z-index: -1;
-  height: 600vh;
+  height: 600dvh;
 }
 </style>

--- a/frontend/src/components/3D/LogoCanvasCamera.vue
+++ b/frontend/src/components/3D/LogoCanvasCamera.vue
@@ -18,7 +18,6 @@ import useRapier from "../../../lib/rapier/useRapier.ts";
 const {
   sectionId,
   scrollTrackId,
-  isLandscape,
   isMobileOrTablet,
   verticalRotationLimit,
   horizontalRotationLimit,
@@ -135,7 +134,7 @@ onBeforeUnmount(() => killAllScrollTriggers(scrollTriggers));
 <template>
   <TresPerspectiveCamera :position="[0, 0, 1]" />
   <OrbitControls
-    v-if="!(isLandscape && isMobileOrTablet)"
+    v-if="!isMobileOrTablet"
     ref="orbitRef"
     :min-distance="0"
     :max-distance="Infinity"


### PR DESCRIPTION
### Description of Changes

- Set touch-events to pan-y on canvas in LogoCanvas
- Set pointer-events to none on canvas in LogoCanvas
- Set OrbitControls to not display if isMobileOrTablet is true in LogoCanvasCamera