### PR TITLE
Revert "Revert "Improved GSAP Animation and Rapier Physics Performance in LogoCanvas""

### DIFF
--- a/frontend/lib/rapier/useRapier.ts
+++ b/frontend/lib/rapier/useRapier.ts
@@ -9,12 +9,13 @@ import {
 } from "@dimforge/rapier3d-compat";
 
 const world = ref<World | null>(null);
-const bodies = ref<{ mesh: Mesh; body: RigidBody }[]>([]);
+const bodies: { mesh: Mesh; body: RigidBody }[] = [];
 
 export default function useRapier() {
   const initRapier = async (gravity = new Vector3(0, -1, 0)) => {
     await init();
     world.value = new World(gravity);
+    world.value.timestep = 1 / 60;
   };
 
   const addRigidBody = (
@@ -25,25 +26,23 @@ export default function useRapier() {
     if (!world.value) return;
 
     const body = world.value.createRigidBody(rigidBodyDesc);
-    body.enableCcd(true);
     world.value.createCollider(colliderDesc, body);
 
-    bodies.value.push({ mesh, body });
+    bodies.push({ mesh, body });
 
     return body;
   };
 
-  const step = (dt: number) => {
-    if (!world.value) return;
+  const step = () => {
+    if (!world.value || bodies.length === 0) return;
 
-    world.value.timestep = dt;
     world.value.step();
 
-    bodies.value.forEach(({ mesh, body }) => {
-      const translation = body.translation();
-      const rotation = body.rotation();
-
-      if (body.isDynamic() || body.isKinematic()) {
+    bodies.forEach(({ mesh, body }) => {
+      if (body.isFixed()) return;
+      if (body.isDynamic() && !body.isSleeping()) {
+        const translation = body.translation();
+        const rotation = body.rotation();
         mesh.position.set(translation.x, translation.y, translation.z);
         mesh.quaternion.set(rotation.x, rotation.y, rotation.z, rotation.w);
       }

--- a/frontend/src/components/3D/LogoCanvas.vue
+++ b/frontend/src/components/3D/LogoCanvas.vue
@@ -544,15 +544,17 @@ watchEffect(() => {
       alpha
       :clearAlpha="0"
     >
-      <LogoCanvasCamera
-        :section-id="sectionId"
-        :scroll-track-id="scrollTrackId"
-        :is-landscape="isLandscape"
-        :is-mobile-or-tablet="isMobileOrTablet"
-        :vertical-rotation-limit="VERTICAL_ROTATION_LIMIT"
-        :horizontal-rotation-limit="HORIZONTAL_ROTATION_LIMIT"
-        :meshes="logoRef?.meshes"
-      />
+      <Suspense>
+        <LogoCanvasCamera
+          :section-id="sectionId"
+          :scroll-track-id="scrollTrackId"
+          :is-landscape="isLandscape"
+          :is-mobile-or-tablet="isMobileOrTablet"
+          :vertical-rotation-limit="VERTICAL_ROTATION_LIMIT"
+          :horizontal-rotation-limit="HORIZONTAL_ROTATION_LIMIT"
+          :meshes="logoRef?.meshes"
+        />
+      </Suspense>
       <Suspense>
         <LottieSphere v-if="!isNight" :src="CLOUDS_LIGHT_LOTTIE_PATH" />
       </Suspense>

--- a/frontend/src/components/3D/LogoCanvasCamera.vue
+++ b/frontend/src/components/3D/LogoCanvasCamera.vue
@@ -7,6 +7,7 @@ import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import {
   ColliderDesc,
+  RigidBody,
   RigidBodyDesc,
   RigidBodyType,
 } from "@dimforge/rapier3d-compat";
@@ -24,7 +25,7 @@ const {
   meshes,
 } = defineProps<LogoCanvasCameraProps>();
 
-const { camera } = useTresContext();
+const { camera, scene } = useTresContext();
 
 let scrollTriggers: ScrollTrigger[] = [];
 const {
@@ -34,7 +35,9 @@ const {
   killAllScrollTriggers,
   buildThreeScrollTriggerConfig,
 } = useScrollTriggers();
-let logoDropped = false;
+let logoCollapsed = false;
+let scrollFinished = true;
+const bodies: RigidBody[] = [];
 const orbitRef = ref<typeof OrbitControls>();
 
 const { initRapier, step, addRigidBody } = useRapier();
@@ -48,6 +51,7 @@ onMounted(async () => {
   await initRapier();
 
   const mesh = new Mesh();
+  scene.value.add(mesh);
   const floorDesc = RigidBodyDesc.fixed().setTranslation(0, -0.08, 0);
   const floorCollider = ColliderDesc.cuboid(10, 0.05, 10);
 
@@ -58,28 +62,23 @@ onMounted(async () => {
       sectionId,
       scrollTrackId,
       (self: ScrollTrigger) => {
-        if (self.progress > 0.99 && !logoDropped && meshes) {
-          logoDropped = true;
+        scrollFinished = self.progress === 1;
+        if (scrollFinished && !logoCollapsed && meshes) {
           meshes.forEach((mesh) => {
             const desc = RigidBodyDesc.kinematicPositionBased();
-            const points = new Float32Array(
-              mesh.geometry.attributes.position.array,
-            );
+            const points = mesh.geometry.attributes.position
+              .array as Float32Array;
             const collider = ColliderDesc.convexHull(points);
             if (!collider) return;
-            setTimeout(() => {
-              const body = addRigidBody(mesh, desc, collider);
-              if (!body) return;
-              body.setBodyType(RigidBodyType.Dynamic, true);
-              body.applyImpulse({ x: 0, y: -0.5, z: 0.5 }, true);
-            }, 1000);
+            const body = addRigidBody(mesh, desc, collider);
+            if (!body) return;
+            body.setBodyType(RigidBodyType.Dynamic, true);
+            body.applyImpulse({ x: 0, y: -0.5, z: 0.5 }, true);
+            logoCollapsed = true;
+            bodies.push(body);
           });
         }
-        if (
-          !isMobileOrTablet &&
-          orbitRef.value?.instance &&
-          self.progress === 1
-        ) {
+        if (!isMobileOrTablet && orbitRef.value?.instance && scrollFinished) {
           orbitRef.value.instance.enabled = true;
         }
       },
@@ -124,24 +123,39 @@ onMounted(async () => {
   refreshScrollTriggers();
 });
 
-onRender(({ delta }: { delta: number }) => {
-  step(delta);
+onRender(() => {
+  let activeBodies = 0;
+
+  bodies.forEach((body) => {
+    if (body.isDynamic() && !body.isSleeping()) {
+      activeBodies++;
+    }
+  });
+
+  if (activeBodies > 0) {
+    step();
+  } else if (logoCollapsed) {
+    bodies.length = 0;
+  }
 });
 
 onBeforeUnmount(() => killAllScrollTriggers(scrollTriggers));
 </script>
 
 <template>
-  <TresPerspectiveCamera :position="[0, 0, 1]" />
-  <OrbitControls
-    v-if="!isMobileOrTablet"
-    ref="orbitRef"
-    :min-distance="0"
-    :max-distance="Infinity"
-    :min-polar-angle="0"
-    :max-polar-angle="Math.PI / verticalRotationLimit"
-    :min-azimuth-angle="-(Math.PI / horizontalRotationLimit)"
-    :max-azimuth-angle="Math.PI / horizontalRotationLimit"
-    :enable-zoom="false"
-  />
+  <TresPerspectiveCamera :position="[0, 0, 1]" v-once />
+  <Suspense>
+    <OrbitControls
+      v-if="!isMobileOrTablet && scrollFinished"
+      ref="orbitRef"
+      :min-distance="0"
+      :max-distance="Infinity"
+      :min-polar-angle="0"
+      :max-polar-angle="Math.PI / verticalRotationLimit"
+      :min-azimuth-angle="-(Math.PI / horizontalRotationLimit)"
+      :max-azimuth-angle="Math.PI / horizontalRotationLimit"
+      :enable-zoom="false"
+      v-once
+    />
+  </Suspense>
 </template>


### PR DESCRIPTION
Reverts timrlai/timrlai#111

This PR had a bug with causing crashes when switching pages due to adding a Suspense tag around LogoCanvasCamera. The next PR will address this but will be easier to merge if this is reverted back again.